### PR TITLE
chore: Alters workflow triggers

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,8 +1,6 @@
 name: Java CI with Maven
 
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 


### PR DESCRIPTION
Only run workflow on a PR, not on a push to master. As this was a waste of cycles.