### PR TITLE
refactor/use-quarkus-elytron-security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,10 +58,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mindrot</groupId>
-            <artifactId>jbcrypt</artifactId>
-            <version>0.4</version>
-        </dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security</artifactId>
+          </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator</artifactId>

--- a/src/main/java/org/example/realworldapi/infrastructure/provider/BCryptHashProvider.java
+++ b/src/main/java/org/example/realworldapi/infrastructure/provider/BCryptHashProvider.java
@@ -1,7 +1,7 @@
 package org.example.realworldapi.infrastructure.provider;
 
 import org.example.realworldapi.domain.model.provider.HashProvider;
-import org.mindrot.jbcrypt.BCrypt;
+import io.quarkus.elytron.security.common.BcryptUtil;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -10,11 +10,11 @@ public class BCryptHashProvider implements HashProvider {
 
   @Override
   public String hashPassword(String password) {
-    return BCrypt.hashpw(password, BCrypt.gensalt());
+    return BcryptUtil.bcryptHash(password);
   }
 
   @Override
   public boolean checkPassword(String plaintext, String hashed) {
-    return BCrypt.checkpw(plaintext, hashed);
+    return BcryptUtil.matches(plaintext, hashed);
   }
 }

--- a/src/test/java/org/example/realworldapi/util/UserEntityUtils.java
+++ b/src/test/java/org/example/realworldapi/util/UserEntityUtils.java
@@ -1,7 +1,7 @@
 package org.example.realworldapi.util;
 
 import org.example.realworldapi.infrastructure.repository.hibernate.entity.UserEntity;
-import org.mindrot.jbcrypt.BCrypt;
+import io.quarkus.elytron.security.common.BcryptUtil;
 
 import java.util.UUID;
 
@@ -12,7 +12,7 @@ public class UserEntityUtils {
     userEntity.setId(UUID.randomUUID());
     userEntity.setUsername(username);
     userEntity.setEmail(email);
-    userEntity.setPassword(BCrypt.hashpw(userPassword, BCrypt.gensalt()));
+    userEntity.setPassword(BcryptUtil.bcryptHash(userPassword));
     return userEntity;
   }
 


### PR DESCRIPTION
- Replaced "org.mindrot.jbcrypt" with "io.quarkus.quarkus-elytron-security" for password hashing

Signed-off-by: Pedro Aguiar <contact@codespearhead.com>