### PR TITLE
refactor/add-equals-and-hashcode-to-businessexception

### DIFF
--- a/src/main/java/org/example/realworldapi/domain/exception/BusinessException.java
+++ b/src/main/java/org/example/realworldapi/domain/exception/BusinessException.java
@@ -1,6 +1,7 @@
 package org.example.realworldapi.domain.exception;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.List;
 import static java.util.Collections.singletonList;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class BusinessException extends RuntimeException {
 
   private final int code;


### PR DESCRIPTION
- Added `@EqualsAndHashCode(callSuper = false)` to `BusinessException` to ensure that equality and hashCode calculations are based solely on business-specific fields (`code` and `messages`).

Closes: https://github.com/appiepollo14/quarkus-realworld-api/issues/85