### PR TITLE
refactor/remove-org.reflections.reflections-dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,6 @@
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>0.10.2</version>
-        </dependency>
-        <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
             <version>4.4.0</version>


### PR DESCRIPTION
- Utilized JPA's Metamodel API to retrieve all managed entity classes.
- Prefixed instance variables and methods with `this.` to enhance code clarity.