### PR TITLE
refactor/apply-the-big-reactive-rename-updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.resteasy.path=/api
+quarkus.rest.path=/api
 
 # Database configuration
 quarkus.datasource.db-kind=postgresql


### PR DESCRIPTION
1. Changed `quarkus-resteasy-jackson` to `quarkus-rest-jackson`.
2. Changed `quarkus.resteasy.path` to `quarkus.resteasy.path`.

***

[1] https://quarkus.io/blog/the-big-rename/
[2] https://pt.quarkus.io/blog/quarkus-3-9-1-released/
[3] https://pt.quarkus.io/blog/resteasy-reactive-smart-dispatch/#new-world-new-rules

***

Signed-off-by: Pedro Aguiar <contact@codespearhead.com>